### PR TITLE
Fix Python 3.7 compatibility and align tooling to 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 23.3.0
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: python3.7
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3

--- a/adbproxy/util.py
+++ b/adbproxy/util.py
@@ -50,7 +50,7 @@ def ssh_uri(sockaddr, hide_pwd: bool = True):
     ret += sockaddr.get("host")
 
     if sockaddr.get("port") is not None:
-        ret += f":{sockaddr.get("port")}"
+        ret += f":{sockaddr.get('port')}"
 
     return ret
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+python_version = 3.7
 disallow_untyped_defs = True
 disallow_any_unimported = True
 no_implicit_optional = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 149
+target-version = ["py37"]
 
 [tool.isort]
 src_paths = ["adbproxy", "tests"]


### PR DESCRIPTION
The f-string in util.py used same-quote nesting (PEP 701), which only
parses on Python 3.12+ and raised a SyntaxError on the 3.7 runtime used
by DeviceFarm, breaking the whole CLI on import. Switch to single quotes
inside the f-string so it parses on 3.7.

Align the toolchain to the 3.7 target: set black target-version to py37,
pin the black pre-commit hook to python3.7, and set mypy python_version
to 3.7.

https://claude.ai/code/session_01KT4x7DGYSRaXQU4qCKZxJ5