### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/adbproxy/aws.py
+++ b/adbproxy/aws.py
@@ -1,11 +1,11 @@
 import asyncio
 import logging
 import re
+from importlib.resources import files
 
 import aiobotocore.session
 import aiohttp
 import yaml
-from pkg_resources import resource_string
 
 from adbproxy.util import random_str
 
@@ -182,7 +182,7 @@ async def run(project_name, device_ids, device_pool, ssh_path):
 
         uploads_to_delete = []
         try:
-            dummy_apk = resource_string(__name__, "dummy.apk")
+            dummy_apk = (files("adbproxy") / "dummy.apk").read_bytes()
 
             test_spec = {
                 "version": 0.1,


### PR DESCRIPTION
## Summary

`pkg_resources` (from setuptools) is deprecated and isn't present in environments without setuptools, so loading the bundled `dummy.apk` in the DeviceFarm flow could fail at runtime. Switch to `importlib.resources.files()`.

```python
# before
from pkg_resources import resource_string
dummy_apk = resource_string(__name__, "dummy.apk")

# after
from importlib.resources import files
dummy_apk = (files("adbproxy") / "dummy.apk").read_bytes()
```

Two-line change, scoped to `adbproxy/aws.py`.

## Note

`importlib.resources.files()` requires **Python ≥3.9**. `master` still declares `requires-python = ">=3.7"`, so this should land alongside/after the floor bump to 3.10 (PR #13). I deliberately did **not** touch `requires-python` here to keep this PR focused. (The 3.7-compatible alternative, `read_binary()`, was avoided because it's deprecated since 3.11 and would warn on the Python 3.11 that DeviceFarm can select.) `aws.py` only runs under the `devicefarm` extra, whose host is Python 3.10+ today.

## Test plan

- [x] `python -m py_compile adbproxy/aws.py`
- [x] Functional check: `(files("adbproxy") / "dummy.apk").read_bytes()` loads the bundled apk (8976 bytes)
- [ ] CI green (note: master's pre-commit config predates the tooling migration)

https://claude.ai/code/session_01KT4x7DGYSRaXQU4qCKZxJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT4x7DGYSRaXQU4qCKZxJ5)_