### PR TITLE
Add Dependabot config for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      python:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` enabling **daily** Dependabot version updates for:

- **`uv`** ecosystem — Python dependencies, read directly from `pyproject.toml` + `uv.lock` (Dependabot supports uv natively).
- **`github-actions`** ecosystem — the actions used in `.github/workflows/ci.yml` (`actions/checkout`, `astral-sh/setup-uv`).

Each ecosystem's updates are grouped into a single PR to cut noise. (Dependabot security alerts are already enabled on the repo separately.)

## Notes

- Now that #14 has merged, the CI workflow runs `pre-commit` (including the `uv-lock` hook) on every PR — so any Dependabot PR that bumps `pyproject.toml` without regenerating `uv.lock` will fail CI rather than merge with a stale lock. No extra lock-regen guard needed.
- Rebased directly onto `master` (was previously stacked on #14).

## Test plan

- [x] `dependabot.yml` parses as valid YAML; `version: 2`, both ecosystems on `daily`
- [ ] Confirm Dependabot picks up the config on GitHub (Insights → Dependency graph → Dependabot) once merged

https://claude.ai/code/session_01KT4x7DGYSRaXQU4qCKZxJ5