### PR TITLE
Use secrets instead of random for password generation

### DIFF
--- a/adbproxy/util.py
+++ b/adbproxy/util.py
@@ -1,5 +1,5 @@
 import asyncio
-import random
+import secrets
 import string
 from urllib.parse import urlparse
 
@@ -55,4 +55,4 @@ def ssh_uri(sockaddr, hide_pwd: bool = True):
 
 
 def random_str(size=6, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
-    return "".join(random.choice(chars) for x in range(size))
+    return "".join(secrets.choice(chars) for x in range(size))


### PR DESCRIPTION
## Summary

`random_str()` was backed by the `random` module (Mersenne Twister), which is **not** cryptographically secure. It's used to generate the DeviceFarm reverse-connection password (`aws.py`: `listen_address.setdefault("password", random_str(16))`), so a predictable PRNG there is a real weakness. Switch the one primitive to `secrets.choice`:

```python
# before
import random
return "".join(random.choice(chars) for x in range(size))

# after
import secrets
return "".join(secrets.choice(chars) for x in range(size))
```

`random_str`'s only caller is the password generator, so securing it in place is the minimal fix — no API or output-format change (still alphanumeric of the requested length).

Left alone on purpose: `upnp.py`'s `randrange`, which only picks an ephemeral port and isn't security-sensitive.

## Test plan

- [x] `random_str(16)` still returns a 16-char alphanumeric string
- [x] `uv run pre-commit run --all-files` — all hooks pass (ruff, ruff-format, uv-lock, ty, meta)

https://claude.ai/code/session_01KT4x7DGYSRaXQU4qCKZxJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT4x7DGYSRaXQU4qCKZxJ5)_