### PR TITLE
Tighten ruff line-length to 139

### DIFF
--- a/adbproxy/adb_proxy.py
+++ b/adbproxy/adb_proxy.py
@@ -3,8 +3,8 @@
 #
 # ADB Proxy
 #
-# In order to access a device in a remote ADB server, the ADB proxy connects to the local ADB server acting like a device, connected via TCP/IP,
-# and to the remote ADB server acting like a client accessing a local device
+# In order to access a device in a remote ADB server, the ADB proxy connects to the local ADB server acting like a
+# device, connected via TCP/IP, and to the remote ADB server acting like a client accessing a local device
 #
 # The ADB protocol is extremely simple, and simply allows device and server to start named streams.
 # However, the protocol used by client<=>ADB-Server and ADB-Server<=>device are a bit different:
@@ -188,7 +188,9 @@ class AdbProxy:
 
         listener, listen_addr = await self.device_endpoint.listen(on_connected)
         proxy = f"tcp:{hostport(listen_addr)}"
-        tunnel_desc = f"{remote} @ Device -> {proxy} @ {self.device_endpoint.local_hostname} -> {local} @ {self.local_endpoint.local_hostname}"
+        tunnel_desc = (
+            f"{remote} @ Device -> {proxy} @ {self.device_endpoint.local_hostname} -> {local} @ {self.local_endpoint.local_hostname}"
+        )
         cmd = f"reverse:forward:{remote};{proxy}"
 
         ret = await self.read_stream(cmd)
@@ -364,7 +366,9 @@ class AdbProxy:
             raise Exception(f"device '{device_id}' not found")
 
         # Fetch device name -- also acts as a quick test that the device is valid
-        device_name = (await read_stream(remote_endpoint, device_path(device_id), "shell:getprop ro.product.model")).decode("utf-8").strip()
+        device_name = (
+            (await read_stream(remote_endpoint, device_path(device_id), "shell:getprop ro.product.model")).decode("utf-8").strip()
+        )
 
         proxy_task = [None]
 
@@ -492,7 +496,9 @@ async def listen_reverse(listen_address, ssh_client=None, wait_for=None, upnp=Fa
                 logger.info("Reverse connection lost")
 
     try:
-        server = (await asyncssh.listen_reverse(tunnel=ssh_client, client_factory=MySSHClient, acceptor=on_connected, **listen_address))._server
+        server = (
+            await asyncssh.listen_reverse(tunnel=ssh_client, client_factory=MySSHClient, acceptor=on_connected, **listen_address)
+        )._server
         async with server:
             socket_addr = dict(listen_address)
             if ssh_client is None:

--- a/adbproxy/aws.py
+++ b/adbproxy/aws.py
@@ -199,7 +199,8 @@ async def run(project_name, device_ids, device_pool, ssh_path):
                     },
                     "test": {
                         "commands": [
-                            f'python -m adbproxy connect-reverse --no-adb-reverse -s $DEVICEFARM_DEVICE_UDID "{ssh_uri(ssh_path, hide_pwd=False)}"'
+                            "python -m adbproxy connect-reverse --no-adb-reverse"
+                            f' -s $DEVICEFARM_DEVICE_UDID "{ssh_uri(ssh_path, hide_pwd=False)}"'
                         ]
                     },
                 },

--- a/adbproxy/main.py
+++ b/adbproxy/main.py
@@ -110,7 +110,9 @@ def main():
     try:
         from .aws import devicefarm
 
-        parser_devicefarm = subparsers.add_parser("devicefarm", parents=[listen_reverse_base_parser], help="Awaits connections from DeviceFarm")
+        parser_devicefarm = subparsers.add_parser(
+            "devicefarm", parents=[listen_reverse_base_parser], help="Awaits connections from DeviceFarm"
+        )
         parser_devicefarm.add_argument("--project", dest="project_name", default="adbproxy", help="Project Name")
         parser_devicefarm_group = parser_devicefarm.add_mutually_exclusive_group()
         parser_devicefarm_group.add_argument("--device-pool", dest="device_pool", default="Default Pool", help="Device Pool")

--- a/adbproxy/upnp.py
+++ b/adbproxy/upnp.py
@@ -36,7 +36,10 @@ class PortMapping:
         self.protocol = protocol
 
     def __str__(self):
-        return f"PortMapping({hostport(self.ext_addr)} -> {hostport(self.lan_addr)}, description={self.description}, protocol={self.protocol})"
+        return (
+            f"PortMapping({hostport(self.ext_addr)} -> {hostport(self.lan_addr)}, "
+            f"description={self.description}, protocol={self.protocol})"
+        )
 
     async def __aenter__(self):
         ext_port = await self.upnp.upnp.get_next_mapping(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ allow-direct-references = true
 packages = ["adbproxy"]
 
 [tool.ruff]
-line-length = 149
+line-length = 139
 target-version = "py310"
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary

Reduce `tool.ruff.line-length` from 149 to 139 and reflow the few lines that went over the new limit:

- `adbproxy/adb_proxy.py` — header comment and two long f-strings (`tunnel_desc`, `device_name`)
- `adbproxy/aws.py` — DeviceFarm test command (this line is replaced entirely by #13, but reflowed here so the PR stands alone on master)
- `adbproxy/main.py` — `add_parser` call for the devicefarm subcommand
- `adbproxy/upnp.py` — `PortMapping.__str__` repr

Pure formatting; no runtime behavior changes.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean