### PR TITLE
Drop # ty: ignore comments in adb_proxy.py

### DIFF
--- a/adbproxy/adb_proxy.py
+++ b/adbproxy/adb_proxy.py
@@ -496,15 +496,15 @@ async def listen_reverse(listen_address, ssh_client=None, wait_for=None, upnp=Fa
                 logger.info("Reverse connection lost")
 
     try:
-        server = (
-            await asyncssh.listen_reverse(tunnel=ssh_client, client_factory=MySSHClient, acceptor=on_connected, **listen_address)
-        )._server
-        async with server:
+        async with await asyncssh.listen_reverse(
+            tunnel=ssh_client, client_factory=MySSHClient, acceptor=on_connected, **listen_address
+        ) as server:
             socket_addr = dict(listen_address)
             if ssh_client is None:
                 # Listening on a plain TCP socket
-                socket_addr["host"] = server.sockets[0].getsockname()[0]  # ty: ignore[unresolved-attribute]
-                socket_addr["port"] = server.sockets[0].getsockname()[1]  # ty: ignore[unresolved-attribute]
+                host, port, *_ = server.get_addresses()[0]
+                socket_addr["host"] = host
+                socket_addr["port"] = port
 
                 test_addrs = {
                     "0.0.0.0": socket.AF_INET,
@@ -521,7 +521,7 @@ async def listen_reverse(listen_address, ssh_client=None, wait_for=None, upnp=Fa
 
             else:
                 # Listening through a SSH tunnel
-                socket_addr["port"] = server.get_port()  # ty: ignore[unresolved-attribute]
+                socket_addr["port"] = server.get_port()
 
                 if ngrok_cmd:
                     async for row in ngrok_cmd.stdout:
@@ -619,15 +619,14 @@ async def connect_reverse(server_address, ssh_client=None, **kwargs):
         logger.info("Disconnected")
 
 
-async def use_tunnels(func, ssh_tunnels=[], ssh_client=None, *args, **kwargs):
+async def use_tunnels(*, func, ssh_tunnels=(), ssh_client=None, **kwargs):
     if ssh_tunnels:
         async with asyncssh.connect(tunnel=ssh_client, **ssh_tunnels[0]) as ssh_client:
             logger.info(f"Jumping through SSH proxy: {ssh_uri(ssh_tunnels[0])}")
             return await use_tunnels(
+                func=func,
                 ssh_tunnels=ssh_tunnels[1:],
                 ssh_client=ssh_client,
-                func=func,
-                *args,  # ty: ignore[parameter-already-assigned]
                 **kwargs,
             )
 


### PR DESCRIPTION
## Summary

Eliminate all four `# ty: ignore` suppressions in `adbproxy/adb_proxy.py`:

- **Three asyncssh-related ignores** were workarounds for [ronf/asyncssh#382](https://github.com/ronf/asyncssh/issues/382), which reached into `SSHAcceptor._server` because `SSHAcceptor` originally didn't support `async with`. That's been fixed upstream — use `SSHAcceptor` as the async context manager directly, and lean on its public `get_addresses()` / `get_port()` methods (which already handle both the plain-TCP and SSH-tunnel cases internally).
- **One `parameter-already-assigned` ignore** on `use_tunnels`' recursive call was a real signature smell: `func` / `ssh_tunnels` / `ssh_client` could collide with `*args`. Make them keyword-only by moving `*args` to the front, and switch the mutable default `[]` for `ssh_tunnels` to `()`. Both call sites already pass kwargs only, so this is API-compatible.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` clean
- [x] `uv run ty check` clean
- [x] `grep "ty: ignore" adbproxy/` returns nothing