### PR TITLE
Type-annotate adb_channel and main; add Stream protocols

### DIFF
--- a/adbproxy/adb_channel.py
+++ b/adbproxy/adb_channel.py
@@ -1,8 +1,11 @@
-def device_path(device_id):
+from .endpoint import Endpoint, StreamReader, StreamWriter
+
+
+def device_path(device_id: str) -> str:
     return f"host:transport:{device_id}"
 
 
-async def open_stream(endpoint, *path):
+async def open_stream(endpoint: Endpoint, *path: str) -> tuple[StreamReader, StreamWriter]:
     """Open a stream to the device"""
     reader, writer = await endpoint.connect_to_adb()
 
@@ -29,16 +32,16 @@ async def open_stream(endpoint, *path):
         raise
 
 
-async def read_stream(*args, **kwargs):
+async def read_stream(endpoint: Endpoint, *path: str) -> bytes:
     """Open a stream to the device, read its contents and close"""
-    reader, writer = await open_stream(*args, **kwargs)
+    reader, writer = await open_stream(endpoint, *path)
     try:
         return await reader.read()
     finally:
         writer.close()
 
 
-async def list_adb_devices(endpoint):
+async def list_adb_devices(endpoint: Endpoint) -> list[str]:
     lines = (await read_stream(endpoint, "host:devices"))[4:].decode("utf-8").splitlines()
     ret = []
     for line in lines:

--- a/adbproxy/endpoint.py
+++ b/adbproxy/endpoint.py
@@ -1,8 +1,20 @@
 import asyncio
 import socket
 from abc import ABC, abstractmethod
+from typing import Protocol
 
 import asyncssh
+
+
+class StreamReader(Protocol):
+    async def read(self, n: int = -1) -> bytes: ...
+    async def readexactly(self, n: int) -> bytes: ...
+
+
+class StreamWriter(Protocol):
+    def write(self, data: bytes) -> None: ...
+    async def drain(self) -> None: ...
+    def close(self) -> None: ...
 
 
 class Endpoint(ABC):

--- a/adbproxy/main.py
+++ b/adbproxy/main.py
@@ -7,7 +7,7 @@ from .adb_proxy import connect, connect_reverse, listen_reverse, use_tunnels
 from .util import sock_addr, ssh_addr
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Creates ADB Proxy connections")
 
     ssh_jump_parser = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
## Summary

First of a series of small per-file PRs splitting the original sprawling type-annotation PR (#21).

- **`adbproxy/adb_channel.py`** — annotate all four functions (`device_path`, `open_stream`, `read_stream`, `list_adb_devices`). `read_stream`'s `*args/**kwargs` signature is also rewritten to `(endpoint, *path)` — matching how it's actually called and what it forwards to `open_stream`.
- **`adbproxy/endpoint.py`** — add `StreamReader` / `StreamWriter` Protocols. The reader/writer pair returned by the endpoint is either `(asyncio.StreamReader, asyncio.StreamWriter)` for `LocalEndpoint` or `(asyncssh.SSHReader, asyncssh.SSHWriter)` for `SshEndpoint`, and those have no common base class. The Protocols cover only what the codebase actually uses (`read`, `readexactly`, `write`, `drain`, `close`); both concrete implementations satisfy them structurally.
- **`adbproxy/main.py`** — `main()` return type.

## Test plan

- [x] `uv run ty check` clean
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean