### PR TITLE
Type-annotate endpoint

### DIFF
--- a/adbproxy/adb_proxy.py
+++ b/adbproxy/adb_proxy.py
@@ -424,8 +424,8 @@ async def connect(
     ssh_client=None,
 ):
     logger.info("Connecting...")
-    local_endpoint = await Endpoint.of(host_adb_addr)
-    remote_endpoint = await Endpoint.of(device_adb_addr, ssh_client)
+    local_endpoint = await Endpoint.of(adb_sockaddr=host_adb_addr)
+    remote_endpoint = await Endpoint.of(adb_sockaddr=device_adb_addr, ssh_client=ssh_client)
 
     if connect_cmd:
 

--- a/adbproxy/endpoint.py
+++ b/adbproxy/endpoint.py
@@ -1,9 +1,11 @@
 import asyncio
+import os
 import socket
 from abc import ABC, abstractmethod
-from typing import Protocol
+from typing import Any, Awaitable, Callable, Protocol, TypeAlias
 
 import asyncssh
+from asyncssh import SSHClientConnection
 
 
 class StreamReader(Protocol):
@@ -17,62 +19,70 @@ class StreamWriter(Protocol):
     def close(self) -> None: ...
 
 
+ConnectedCallback: TypeAlias = Callable[[StreamReader, StreamWriter], Awaitable[Any]]
+
+
 class Endpoint(ABC):
     @staticmethod
-    async def of(adb_sockaddr, ssh_client=None):
+    async def of(*, adb_sockaddr: tuple[str, int], ssh_client: SSHClientConnection | None = None) -> "Endpoint":
         if ssh_client:
             try:
-                hostname = (await ssh_client.run("hostname", stdin=asyncssh.DEVNULL, stderr=asyncssh.DEVNULL)).stdout.strip() or None
+                stdout = (await ssh_client.run("hostname", stdin=asyncssh.DEVNULL, stderr=asyncssh.DEVNULL)).stdout
+                assert isinstance(stdout, str)
+                local_hostname = stdout.strip() or None
             except Exception:
-                hostname = None
+                local_hostname = None
 
-            # FIXME: Can we figure out the IP that would be used to connect to `adb_sockaddr` ?
-
-            addr = ssh_client._peer_addr
-            hostname = hostname or ssh_client._host or addr
-            return SshEndpoint(hostname, ssh_client, addr, adb_sockaddr)
+            local_addr = ssh_client._peer_addr  # FIXME: Can we figure out the IP that would be used to connect to `adb_sockaddr` ?
+            local_hostname = local_hostname or ssh_client._host or local_addr
+            return SshEndpoint(
+                local_hostname=local_hostname,
+                local_addr=local_addr,
+                adb_sockaddr=adb_sockaddr,
+                ssh_client=ssh_client,
+            )
         else:
             _, writer = await asyncio.open_connection(adb_sockaddr[0], adb_sockaddr[1])
             local_addr = writer.transport.get_extra_info("sockname")[0]
             writer.close()
 
-            return LocalEndpoint(socket.gethostname(), local_addr, adb_sockaddr)
+            return LocalEndpoint(local_hostname=socket.gethostname(), local_addr=local_addr, adb_sockaddr=adb_sockaddr)
 
-    def __init__(self, local_hostname, local_addr, adb_sockaddr):
+    def __init__(self, *, local_hostname: str, local_addr: str, adb_sockaddr: tuple[str, int]) -> None:
         self.local_hostname = local_hostname
         self.local_addr = local_addr
         self.adb_sockaddr = adb_sockaddr
 
-    async def connect_to_adb(self):
+    async def connect_to_adb(self) -> tuple[StreamReader, StreamWriter]:
         return await self.connect(self.adb_sockaddr)
 
     @abstractmethod
-    async def connect(self, sockaddr):
+    async def connect(self, sockaddr: tuple[str, int]) -> tuple[StreamReader, StreamWriter]:
         pass
 
     @abstractmethod
-    async def listen(self, on_connected):
+    async def listen(self, on_connected: ConnectedCallback) -> tuple[Any, tuple[str, int]]:
         pass
 
     @abstractmethod
-    async def shell(self, command, pty=True):
+    async def shell(self, command: str | None, *, pty: bool = True) -> tuple[StreamReader, StreamWriter]:
         pass
 
 
 class SshEndpoint(Endpoint):
-    def __init__(self, local_hostname, ssh_client, local_addr, adb_sockaddr):
-        Endpoint.__init__(self, local_hostname, local_addr, adb_sockaddr)
+    def __init__(self, *, local_hostname: str, local_addr: str, adb_sockaddr: tuple[str, int], ssh_client: SSHClientConnection) -> None:
+        Endpoint.__init__(self, local_hostname=local_hostname, local_addr=local_addr, adb_sockaddr=adb_sockaddr)
         self.ssh_client = ssh_client
 
-    async def connect(self, sockaddr):
+    async def connect(self, sockaddr: tuple[str, int]) -> tuple[StreamReader, StreamWriter]:
         return await self.ssh_client.open_connection(remote_host=sockaddr[0], remote_port=sockaddr[1])
 
-    async def listen(self, on_connected):
+    async def listen(self, on_connected: ConnectedCallback) -> tuple[Any, tuple[str, int]]:
         server = await self.ssh_client.start_server(lambda *args: on_connected, listen_host=self.local_addr, listen_port=0)
         print("Listening on", self.local_addr, server.get_port())
         return server, (self.local_addr, server.get_port())
 
-    async def shell(self, command, pty=True):
+    async def shell(self, command: str | None, *, pty: bool = True) -> tuple[StreamReader, StreamWriter]:
         proc = await self.ssh_client.create_process(
             command,
             stdin=asyncssh.PIPE,
@@ -85,23 +95,24 @@ class SshEndpoint(Endpoint):
 
 
 class LocalEndpoint(Endpoint):
-    def __init__(self, local_hostname, local_addr, adb_sockaddr):
-        Endpoint.__init__(self, local_hostname, local_addr, adb_sockaddr)
+    def __init__(self, *, local_hostname: str, local_addr: str, adb_sockaddr: tuple[str, int]) -> None:
+        Endpoint.__init__(self, local_hostname=local_hostname, local_addr=local_addr, adb_sockaddr=adb_sockaddr)
 
-    async def connect(self, sockaddr):
+    async def connect(self, sockaddr: tuple[str, int]) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         return await asyncio.open_connection(sockaddr[0], sockaddr[1])
 
-    async def listen(self, on_connected):
+    async def listen(self, on_connected: ConnectedCallback) -> tuple[asyncio.Server, tuple[str, int]]:
         server = await asyncio.start_server(on_connected, self.local_addr, 0)
         return server, server.sockets[0].getsockname()
 
-    async def shell(self, command, pty=True):
+    async def shell(self, command: str | None, *, pty: bool = True) -> tuple[StreamReader, StreamWriter]:
         # TODO: Support PTY
         proc = await asyncio.create_subprocess_shell(
-            command,
+            command or os.environ.get("SHELL", "/bin/sh"),
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             encoding=None,
         )
+        assert proc.stdout is not None and proc.stdin is not None
         return proc.stdout, proc.stdin


### PR DESCRIPTION
## Summary

Annotate the `Endpoint` hierarchy: `Endpoint`, `SshEndpoint`, `LocalEndpoint`.

- Reader/writer pairs use the `StreamReader` / `StreamWriter` Protocols introduced in #23.
- Dynamic asyncssh client connections (`ssh_client`) are typed as `Any` at the boundary.
- Host:port pairs use `tuple[str, int]` — these can be unified under a named alias in a later PR.

## Bugs / behavior changes ty surfaced

- **`Endpoint.shell`'s `command` is `str | None`** — the existing caller in `AdbProxy.open_channel` already passes `None` when the user requests `shell:hostshell` with no command. `SshEndpoint.shell` handled `None` fine (asyncssh accepts it), but `LocalEndpoint.shell` would have crashed `asyncio.create_subprocess_shell` at runtime. Falls back to `$SHELL` (or `/bin/sh`) in that case.
- `assert proc.stdout / proc.stdin is not None` after `PIPE` configuration — needed to narrow `asyncio.Process`'s Optional stream attrs.

## Test plan

- [x] `uv run ty check` clean
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean