### PR TITLE
Replace aiohttp with httpx in DeviceFarm uploads

### DIFF
--- a/adbproxy/aws.py
+++ b/adbproxy/aws.py
@@ -9,7 +9,7 @@ from importlib.resources import files
 from typing import TYPE_CHECKING, Any
 
 import aiobotocore.session
-import aiohttp
+import httpx
 import yaml
 
 from adbproxy.util import random_str
@@ -159,7 +159,7 @@ async def find_devices(client: DeviceFarmClient, *, project_arn: str, device_ids
 async def upload(
     *,
     client: DeviceFarmClient,
-    http_session: aiohttp.ClientSession,
+    http_session: httpx.AsyncClient,
     project_arn: str,
     name: str,
     type: UploadTypeType,
@@ -170,7 +170,7 @@ async def upload(
     arn = upload_info["arn"]
     try:
         # Perform the actual upload
-        await http_session.put(upload_info["url"], data=data)
+        await http_session.put(upload_info["url"], content=data)
 
         # Wait until upload is ready to use
         while True:
@@ -195,7 +195,7 @@ async def run(*, project_name: str, device_ids: list[str] | None, device_pool: s
 
     async with (
         aiobotocore.session.get_session().create_client("devicefarm", region_name="us-west-2") as client,
-        aiohttp.ClientSession() as http_session,
+        httpx.AsyncClient() as http_session,
     ):
         project_arn = await find_project_arn(client, project_name=project_name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
 [project.optional-dependencies]
 devicefarm = [
     "aiobotocore>=2.5.0",
-    "aiohttp>=3.8",
     "botocore[crt]",
+    "httpx>=0.25",
 ]
 upnp = [
     "async-upnp-client>=0.40",

--- a/uv.lock
+++ b/uv.lock
@@ -15,8 +15,8 @@ dependencies = [
 [package.optional-dependencies]
 devicefarm = [
     { name = "aiobotocore" },
-    { name = "aiohttp" },
     { name = "botocore", extra = ["crt"] },
+    { name = "httpx" },
 ]
 upnp = [
     { name = "async-upnp-client" },
@@ -33,11 +33,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiobotocore", marker = "extra == 'devicefarm'", specifier = ">=2.5.0" },
-    { name = "aiohttp", marker = "extra == 'devicefarm'", specifier = ">=3.8" },
     { name = "argcomplete", specifier = ">=3.1.1" },
     { name = "async-upnp-client", marker = "extra == 'upnp'", specifier = ">=0.40" },
     { name = "asyncssh", specifier = ">=2.19.0" },
     { name = "botocore", extras = ["crt"], marker = "extra == 'devicefarm'" },
+    { name = "httpx", marker = "extra == 'devicefarm'", specifier = ">=0.25" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 provides-extras = ["devicefarm", "upnp"]
@@ -221,6 +221,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -333,6 +347,15 @@ wheels = [
 [package.optional-dependencies]
 crt = [
     { name = "awscrt" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
 ]
 
 [[package]]
@@ -505,6 +528,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -632,6 +667,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`adbproxy/aws.py` used `aiohttp` for a single PUT to S3 (the DeviceFarm upload URL). Swap that single use for `httpx.AsyncClient` and drop the explicit `aiohttp>=3.8` from the `devicefarm` extra.

- `import aiohttp` → `import httpx`
- `aiohttp.ClientSession()` → `httpx.AsyncClient()`
- `http_session.put(url, data=data)` → `http_session.put(url, content=data)` (httpx's `data` is form-data; `content` is the raw-bytes equivalent of aiohttp's `data`)
- Type annotation: `aiohttp.ClientSession` → `httpx.AsyncClient`

`aiohttp` is still pulled in transitively by `async-upnp-client` when the `upnp` extra is installed (used internally via `async_upnp_client.aiohttp`), so no upnp regression.

## Test plan

- [x] `uv run ty check` clean
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean
- [ ] End-to-end DeviceFarm run to confirm the S3 PUT still works