### PR TITLE
PTY-backed hostshell, for LocalEndpoint and over reverse-SSH tunnels

### DIFF
--- a/adbproxy/adb_proxy.py
+++ b/adbproxy/adb_proxy.py
@@ -27,7 +27,7 @@ from ipaddress import IPv4Address
 
 import asyncssh
 
-from .endpoint import Endpoint
+from .endpoint import Endpoint, spawn
 from .util import hostport, ssh_uri
 
 
@@ -623,13 +623,72 @@ async def connect_reverse(server_address, ssh_client=None, **kwargs):
             logger.info(f"Incoming connection to {dest_host}:{dest_port}")
             return True
 
+    async def shell_factory(process: asyncssh.SSHServerProcess) -> None:
+        """Handle a session/shell request — spawn a PTY-backed shell and bridge it to the SSH channel.
+
+        We bridge stdin/stdout manually instead of using process.redirect because PTYs have no
+        half-close: forwarding an EOF on stdin to the PTY master would close the whole fd and
+        kill the subprocess.
+        """
+        pty = bool(process.get_terminal_type())
+        logger.info(f"hostshell session: command={process.command!r}, pty={pty}")
+        try:
+            reader, writer, exitcode = await spawn(
+                process.command,
+                pty=pty,
+                env={**os.environ, **(process.env or {})},
+            )
+        except Exception as e:
+            logger.warning(f"shell spawn failed: {e}")
+            process.exit(1)
+            return
+
+        async def stdin_pump() -> None:
+            # Forwards SSH stdin → PTY writer. When SSH stdin EOFs (the client closed
+            # its write side) we deliberately do NOT close the PTY writer — that would
+            # kill bash immediately. sshd treats PTY sessions the same way: bash stays
+            # alive until it exits on its own or the SSH session is torn down.
+            try:
+                while True:
+                    data = await process.stdin.read(4096)
+                    if not data:
+                        break
+                    writer.write(data)
+                    await writer.drain()
+            except Exception as e:
+                logger.warning(f"hostshell stdin pump exception: {type(e).__name__}: {e}")
+
+        async def stdout_pump() -> None:
+            try:
+                while True:
+                    data = await reader.read(4096)
+                    if not data:
+                        break
+                    process.stdout.write(data)
+                    await process.stdout.drain()
+            except Exception as e:
+                logger.warning(f"hostshell stdout pump exception: {type(e).__name__}: {e}")
+            finally:
+                process.stdout.close()
+
+        _stdin_task = asyncio.create_task(stdin_pump())
+        _stdout_task = asyncio.create_task(stdout_pump())
+
+        rc = await exitcode
+        writer.close()
+        logger.info(f"hostshell session exited with code {rc}")
+        process.exit(rc)
+
     server_host_key = asyncssh.generate_private_key("ecdsa-sha2-nistp256")
     ssh_conn = await asyncssh.connect_reverse(
         server_factory=MySSHServer,
+        process_factory=shell_factory,
         tunnel=ssh_client,
         host=server_address["host"],
         port=server_address["port"],
         server_host_keys=[server_host_key],
+        line_editor=False,
+        encoding=None,
     )
 
     async with ssh_conn:

--- a/adbproxy/adb_proxy.py
+++ b/adbproxy/adb_proxy.py
@@ -631,7 +631,7 @@ async def connect_reverse(server_address, ssh_client=None, **kwargs):
         kill the subprocess.
         """
         pty = bool(process.get_terminal_type())
-        logger.info(f"hostshell session: command={process.command!r}, pty={pty}")
+        logger.info(f"shell session: command={process.command!r}, pty={pty}")
         try:
             reader, writer, exitcode = await spawn(
                 process.command,
@@ -656,7 +656,7 @@ async def connect_reverse(server_address, ssh_client=None, **kwargs):
                     writer.write(data)
                     await writer.drain()
             except Exception as e:
-                logger.warning(f"hostshell stdin pump exception: {type(e).__name__}: {e}")
+                logger.warning(f"shell stdin pump exception: {type(e).__name__}: {e}")
 
         async def stdout_pump() -> None:
             try:
@@ -667,7 +667,7 @@ async def connect_reverse(server_address, ssh_client=None, **kwargs):
                     process.stdout.write(data)
                     await process.stdout.drain()
             except Exception as e:
-                logger.warning(f"hostshell stdout pump exception: {type(e).__name__}: {e}")
+                logger.warning(f"shell stdout pump exception: {type(e).__name__}: {e}")
             finally:
                 process.stdout.close()
 
@@ -676,7 +676,7 @@ async def connect_reverse(server_address, ssh_client=None, **kwargs):
 
         rc = await exitcode
         writer.close()
-        logger.info(f"hostshell session exited with code {rc}")
+        logger.info(f"shell session exited with code {rc}")
         process.exit(rc)
 
     server_host_key = asyncssh.generate_private_key("ecdsa-sha2-nistp256")

--- a/adbproxy/endpoint.py
+++ b/adbproxy/endpoint.py
@@ -1,7 +1,11 @@
 import asyncio
+import fcntl
 import os
 import socket
+import termios
 from abc import ABC, abstractmethod
+from asyncio.streams import FlowControlMixin
+from pty import openpty
 from typing import Any, Awaitable, Callable, Protocol, TypeAlias
 
 import asyncssh
@@ -19,7 +23,93 @@ class StreamWriter(Protocol):
     def close(self) -> None: ...
 
 
+async def spawn(
+    command: str | None,
+    *,
+    pty: bool = True,
+    env: dict[str, str] | None = None,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.Future[int]]:
+    """Spawn `command` (or $SHELL) and return (stdout, stdin, exitcode_future).
+
+    With pty=True (default), allocates a real PTY pair and gives the slave to the
+    subprocess (with setsid + TIOCSCTTY in preexec_fn). bash sees a TTY → interactive
+    mode → prompts, colors, line editing, job control.
+
+    With pty=False, falls back to pipe-based I/O.
+
+    `env` follows standard subprocess semantics: None inherits the parent process
+    env; a dict replaces it entirely. Callers that want "inherit + override" should
+    pass `{**os.environ, **delta}` themselves.
+    """
+    cmd = command or os.environ.get("SHELL", "/bin/sh")
+    loop = asyncio.get_running_loop()
+
+    if not pty:
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=env,
+        )
+        assert proc.stdout is not None and proc.stdin is not None
+        return proc.stdout, proc.stdin, loop.create_task(proc.wait())
+
+    master_fd, slave_fd = openpty()
+    # Hold a second slave reference in the parent so the master never observes
+    # "no slave open" (which on Linux turns master reads into EIO and can lose
+    # the buffered subprocess output). We close it once the subprocess exits.
+    parent_slave_fd = os.dup(slave_fd)
+
+    def _make_controlling_terminal() -> None:
+        # Make slave_fd the controlling terminal so bash gets job control.
+        os.setsid()
+        fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            preexec_fn=_make_controlling_terminal,
+            env=env,
+        )
+    finally:
+        os.close(slave_fd)
+
+    # The read side owns master_fd; the writer uses a dup so the two halves
+    # can be closed independently.
+    reader = asyncio.StreamReader()
+    await loop.connect_read_pipe(
+        lambda: asyncio.StreamReaderProtocol(reader),
+        os.fdopen(master_fd, "rb", buffering=0),
+    )
+    write_transport, write_protocol = await loop.connect_write_pipe(
+        FlowControlMixin,
+        os.fdopen(os.dup(master_fd), "wb", buffering=0),
+    )
+    writer = asyncio.StreamWriter(write_transport, write_protocol, reader, loop)
+
+    async def _wait_and_release_slave() -> int:
+        rc = await proc.wait()
+        os.close(parent_slave_fd)  # now master will see clean EOF after the buffer drains
+        return rc
+
+    return reader, writer, loop.create_task(_wait_and_release_slave())
+
+
 ConnectedCallback: TypeAlias = Callable[[StreamReader, StreamWriter], Awaitable[Any]]
+
+
+# Env vars injected into a hostshell so the user can tell at a glance that the
+# prompt they see is the adbproxy's local shell. The PROMPT_COMMAND captures the
+# original PS1 once and re-applies the prefix on every prompt — survives bash
+# overriding PS1 from .bashrc, and never stacks "[adbproxy] [adbproxy] ...".
+_HOSTSHELL_ENV: dict[str, str] = {
+    "PS1": r"[adbproxy] \u@\h:\w\$ ",
+    "PROMPT_COMMAND": r'_orig_ps1=${_orig_ps1-$PS1}; PS1="[adbproxy] $_orig_ps1"',
+}
 
 
 class Endpoint(ABC):
@@ -133,6 +223,7 @@ class SshEndpoint(Endpoint):
             stderr=asyncssh.STDOUT,
             encoding=None,
             term_type="xterm-color" if pty else None,
+            env=_HOSTSHELL_ENV,
         )
         return proc.stdout, proc.stdin
 
@@ -149,13 +240,5 @@ class LocalEndpoint(Endpoint):
         return server, server.sockets[0].getsockname()
 
     async def shell(self, command: str | None, *, pty: bool = True) -> tuple[StreamReader, StreamWriter]:
-        # TODO: Support PTY
-        proc = await asyncio.create_subprocess_shell(
-            command or os.environ.get("SHELL", "/bin/sh"),
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            encoding=None,
-        )
-        assert proc.stdout is not None and proc.stdin is not None
-        return proc.stdout, proc.stdin
+        reader, writer, _exitcode = await spawn(command, pty=pty, env={**os.environ, **_HOSTSHELL_ENV})
+        return reader, writer


### PR DESCRIPTION
## Summary

Make \`shell:hostshell\` produce a real interactive shell experience — prompt, colors, line editing, history, job control — in three places:

1. **LocalEndpoint** (hostshell on the proxy machine)
2. **SshEndpoint via real \`sshd\`** (e.g. \`adbproxy connect -J localhost\`)
3. **SshEndpoint via our reverse SSH server** (\`adbproxy connect-reverse\`)

## What's added

### \`endpoint.spawn(command, *, pty=True, env=None)\`
Single helper used by every shell path. Returns \`(reader, writer, exitcode_future)\`.

- **PTY mode** (default): \`pty.openpty()\` + a \`preexec_fn\` that does \`os.setsid()\` + \`fcntl.ioctl(slave_fd, TIOCSCTTY, 0)\`. Bash sees a TTY → interactive mode.
- **Pipe mode** (\`pty=False\`): plain stdin/stdout pipes.
- **Graceful PTY fallback**: if \`openpty()\` raises \`OSError\` (restricted containers like AWS Device Farm exhaust the PTY namespace), spawn warns and falls back to pipe mode instead of crashing.
- \`env\` follows standard subprocess semantics — None inherits, dict replaces. Caller is responsible for merging.

### PTY master wrapped with stock asyncio streams
- \`asyncio.StreamReader\` for the read side via \`connect_read_pipe\`.
- \`asyncio.StreamWriter\` over \`FlowControlMixin\` for the write side, using \`os.dup(master_fd)\` so the two halves close independently.
- A second \`parent_slave_fd = os.dup(slave_fd)\` is held open in the parent until \`proc.wait()\` returns. Without this, Linux turns master reads into \`EIO\` the moment the subprocess closes its slave — and short-lived commands can lose all their buffered output.

### \`_HOSTSHELL_ENV\`
Marks the prompt with \`[adbproxy]\` so users can tell at a glance they're in the proxy's local shell:

\`\`\`python
{
    "PS1": r"[adbproxy] \\u@\\h:\\w\\$ ",
    "PROMPT_COMMAND": r'_orig_ps1=${_orig_ps1-$PS1}; PS1="[adbproxy] $_orig_ps1"',
}
\`\`\`

The \`PROMPT_COMMAND\` trick captures the original \`PS1\` once and re-applies the prefix on every prompt — survives \`.bashrc\` overriding \`PROMPT_COMMAND\` later, and never stacks \`[adbproxy] [adbproxy] ...\`.

> **Note for real \`sshd\`**: env requests are filtered by \`AcceptEnv\` in \`sshd_config\` (defaults to \`LANG\`/\`LC_*\`). To get the banner over \`adbproxy connect -J <real-sshd>\`, add \`AcceptEnv PS1 PROMPT_COMMAND\` and reload \`sshd\`. Our reverse SSH server has no such filter.

### \`shell_factory\` for the reverse SSH server (\`connect_reverse\`)
asyncssh's \`process_factory\` was previously absent — session requests fell through to defaults and bash got no PTY. The new handler:

- Spawns via \`spawn()\` using \`process.command\` / \`process.env\` / \`process.get_terminal_type()\`.
- Manual stdin/stdout pumps instead of \`process.redirect\` (the latter forwards SSH-stdin EOF to \`write_eof\`, which on a PTY master closes the whole fd and kills bash; PTYs have no half-close).
- \`stdin_pump\` deliberately does NOT close the PTY writer on SSH-stdin EOF — matches \`sshd\`'s PTY behavior. Bash stays alive until it exits on its own.
- After \`await exitcode\` the writer is explicitly closed.

### asyncssh server options
Two server-level fixes were needed for the bytes to flow:

- \`line_editor=False\` — asyncssh wraps PTY-mode server channels with a built-in text-mode line editor that does \`data.replace('\\n', '\\r\\n')\`. Redundant (the PTY line discipline handles it) and crashes on bytes.
- \`encoding=None\` at the connection level — sets binary mode on **both** the channel and the session. The session encoding is separate from the channel encoding; setting only one causes \`TypeError: sequence item 0: expected str instance, bytes found\` in the session-level read.

## Files

- \`adbproxy/endpoint.py\` (+103 / −8) — \`spawn()\`, \`_HOSTSHELL_ENV\`, \`LocalEndpoint.shell\` rewrite, fallback logger
- \`adbproxy/adb_proxy.py\` (+60 / −3) — \`shell_factory\` + \`line_editor=False\` / \`encoding=None\` on \`asyncssh.connect_reverse\`

## Test plan

- [x] \`uv run ty check\` clean
- [x] \`uv run ruff check .\` / \`uv run ruff format --check .\` clean
- [x] Local: \`adb shell hostshell\` over \`adbproxy connect\` — interactive prompt
- [x] SSH: \`adb shell hostshell\` over \`adbproxy connect -J localhost\` (with \`AcceptEnv PS1 PROMPT_COMMAND\`) — prompt + banner
- [x] Reverse SSH: \`adb shell hostshell\` over \`adbproxy listen-reverse\` + \`adbproxy connect-reverse\` — prompt + banner
- [x] One-shot: \`adb shell hostshell ls\` — file listing
- [x] PTY-less fallback in restricted containers (Device Farm) — pipe mode with warning, basic commands work

## Known limitations

- \`adb shell hostshell\` *without* \`-tt\` is a one-shot from adb's perspective; interactive use over the bare \`adb shell hostshell\` invocation is limited by adb closing its stdin after sending the command. (Bare \`adb shell\` is the interactive form, but that conflicts with our prefix-routing.) Follow-up PR can register hostshell as its own ADB device serial — then \`adb -s host-shell shell\` is true interactive.