### PR TITLE
Fall back to pipe mode when openpty fails

### DIFF
--- a/adbproxy/endpoint.py
+++ b/adbproxy/endpoint.py
@@ -1,5 +1,6 @@
 import asyncio
 import fcntl
+import logging
 import os
 import socket
 import termios
@@ -10,6 +11,9 @@ from typing import Any, Awaitable, Callable, Protocol, TypeAlias
 
 import asyncssh
 from asyncssh import SSHClientConnection
+
+
+logger = logging.getLogger("adb-proxy")
 
 
 class StreamReader(Protocol):
@@ -44,6 +48,15 @@ async def spawn(
     cmd = command or os.environ.get("SHELL", "/bin/sh")
     loop = asyncio.get_running_loop()
 
+    if pty:
+        try:
+            master_fd, slave_fd = openpty()
+        except OSError as e:
+            # Restricted containers (e.g. AWS Device Farm) can exhaust the PTY namespace.
+            # Fall back to pipe mode so basic commands still work.
+            logger.warning(f"PTY allocation failed ({e}); falling back to pipe mode")
+            pty = False
+
     if not pty:
         proc = await asyncio.create_subprocess_shell(
             cmd,
@@ -54,8 +67,6 @@ async def spawn(
         )
         assert proc.stdout is not None and proc.stdin is not None
         return proc.stdout, proc.stdin, loop.create_task(proc.wait())
-
-    master_fd, slave_fd = openpty()
     # Hold a second slave reference in the parent so the master never observes
     # "no slave open" (which on Linux turns master reads into EIO and can lose
     # the buffered subprocess output). We close it once the subprocess exits.


### PR DESCRIPTION
## Summary

\`spawn()\` now catches \`OSError\` from \`pty.openpty()\` and degrades to pipe-based subprocess I/O instead of aborting the session.

Restricted Linux containers (most visibly **AWS DeviceFarm**) can exhaust the PTY namespace; before this fix, \`shell:hostshell\` against such targets crashed with:

\`\`\`
WARNING:adb-proxy:shell spawn failed: out of pty devices
\`\`\`

The pipe fallback loses prompts / colors / line editing / job control, but keeps \`adb shell hostshell <cmd>\` and the non-interactive paths usable. A warning is logged on the way down so the degradation isn't silent.

## Test plan

- [x] \`uv run ty check\` clean
- [x] \`uv run ruff check .\` / \`uv run ruff format --check .\` clean
- [ ] Run on a real Device Farm session — verify the warning fires and basic commands work without crashing