### PR TITLE
Pass -i to the shell so it runs interactively without a PTY

### DIFF
--- a/adbproxy/endpoint.py
+++ b/adbproxy/endpoint.py
@@ -45,7 +45,10 @@ async def spawn(
     env; a dict replaces it entirely. Callers that want "inherit + override" should
     pass `{**os.environ, **delta}` themselves.
     """
-    cmd = command or os.environ.get("SHELL", "/bin/sh")
+    # For the no-command (interactive shell) case, force -i so the shell prints a prompt
+    # even when there's no PTY (e.g. the openpty fallback below, or pty=False on purpose).
+    # With a PTY bash auto-detects interactive mode; -i is harmlessly redundant there.
+    cmd = command or (os.environ.get("SHELL", "/bin/sh") + " -i")
     loop = asyncio.get_running_loop()
 
     if pty:


### PR DESCRIPTION
## Summary

When \`openpty()\` fails (e.g. AWS DeviceFarm exhausts the PTY namespace) or \`pty=False\` is passed on purpose, the shell was started with pipe stdin → bash sees no TTY → enters non-interactive mode → suppresses the prompt and exits on stdin EOF.

Append \`-i\` to the shell invocation in the no-command (interactive) case so bash unconditionally enters interactive mode regardless of TTY detection. With a PTY, \`-i\` is harmlessly redundant; without one, it's what makes hostshell still feel like a shell.

## Result

\`spawn(None, pty=False)\` previously:
- bash exits silently on stdin EOF, no prompt visible.

Now:
\`\`\`
bash: cannot set terminal process group (...): inappropriate ioctl
bash: no job control in this shell
paulo@laptop:~/Workspace/adb-proxy$ pwd
/home/paulo/Workspace/adb-proxy
paulo@laptop:~/Workspace/adb-proxy$ exit
\`\`\`

Job-control warnings still appear (no controlling terminal without a PTY) but the shell is usable.

## Test plan

- [x] \`uv run ty check\` / \`uv run ruff check\` clean
- [x] Smoke test: \`spawn(None, pty=False)\` returns a usable interactive shell
- [ ] Verify on a real Device Farm session